### PR TITLE
Fixed InlineKeyboardMarkup

### DIFF
--- a/telebof/src/main/java/io/github/natanimn/types/keyboard/InlineKeyboardMarkup.java
+++ b/telebof/src/main/java/io/github/natanimn/types/keyboard/InlineKeyboardMarkup.java
@@ -30,6 +30,8 @@ public class InlineKeyboardMarkup implements Markup {
     }
 
     public InlineKeyboardMarkup(InlineKeyboardButton[][] keyboard) {
+        this.inline_keyboard = new ArrayList<>();
+        
         Arrays.stream(keyboard)
                 .map(List::of)
                 .forEach(inline_keyboard::add);


### PR DESCRIPTION
Calling new InlineKeyboardMarkup(InlineKeyboardButton[][] keyboard) with this constructor leaves the inline keyboard uninitialized, causing it to be null